### PR TITLE
Changed Build Location, added DerivedData/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+DerivedData/

--- a/iOS-Soundscape.xcodeproj/project.xcworkspace/xcuserdata/Mindspyk.xcuserdatad/WorkspaceSettings.xcsettings
+++ b/iOS-Soundscape.xcodeproj/project.xcworkspace/xcuserdata/Mindspyk.xcuserdatad/WorkspaceSettings.xcsettings
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildLocationStyle</key>
+	<string>UseAppPreferences</string>
+	<key>CustomBuildLocationType</key>
+	<string>RelativeToDerivedData</string>
+	<key>DerivedDataCustomLocation</key>
+	<string>DerivedData</string>
+	<key>DerivedDataLocationStyle</key>
+	<string>WorkspaceRelativePath</string>
+	<key>IssueFilterStyle</key>
+	<string>ShowActiveSchemeOnly</string>
+	<key>LiveSourceIssuesEnabled</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
This commit _should_ make it so that when XCode builds the project, it will place the .app file in the same directory as the project in `DerivedData/`.  However, the `.gitignore` file lists `DerivedData/` so that git won't include the .app bundle (which makes pushing and pull requests really slow).
